### PR TITLE
feat(scrollUpBy): add flag to detect "scroll up by N", as alternative to "scroll when N to top"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 Inspired by [ng-infinite-scroll](https://github.com/sroze/ngInfiniteScroll) directive for angular (> 2, 4).
 
 ## Angular Support
-Supports Angular **> 4**  
+Supports Angular **> 4**
 For Angular version **<= 2.3.1**, you can use ```npm i angular2-infinite-scroll``` (latest version is 0.3.42) - please notice **the angular2-infinite-scroll** package is deprecated
 
 ## Angular Consulting Services
 I'm a Senior Javascript Engineer & A Front End Consultant at [Orizens](http://orizens.com).
-My services include:  
-- consulting to companies and startups on how to approach code in their projects and keep it maintainable.  
-- I provide project bootstrapping and development - while afterwards, I integrate it on site and guide the team on it.  
+My services include:
+- consulting to companies and startups on how to approach code in their projects and keep it maintainable.
+- I provide project bootstrapping and development - while afterwards, I integrate it on site and guide the team on it.
 
 [Contact Me Here](http://orizens.com/contact)
 
@@ -29,17 +29,18 @@ Currently supported attributes:
 * **scrolled**<_function_> - this will callback if the distance threshold has been reached on a scroll down.
 * **scrolledUp**<_function_> - (event: InfiniteScrollEvent) - this will callback if the distance threshold has been reached on a scroll up.
 * **scrollWindow**<_boolean_> - (optional, default: **true**) - listens to the window scroll instead of the actual element scroll. this allows to invoke a callback function in the scope of the element while listenning to the window scroll.
+* **scrollUpBy**<_boolean_> - (optional, default: **false**) - triggers **scrolledUp** when we have scrolled up _by_ **infiniteScrollUpDistance**, not **infiniteScrollUpDistance**-to-top.
 * **immediateCheck**<_boolean_> - (optional, default: **false**) - invokes the handler immediately to check if a scroll event has been already triggred when the page has been loaded (i.e. - when you refresh a page that has been scrolled).
 * **infiniteScrollDisabled**<_boolean_> - (optional, default: **false**) - doesn't invoke the handler if set to true
 
 ## Behavior
-By default, the directive listens to the **window scroll** event and invoked the callback.  
+By default, the directive listens to the **window scroll** event and invoked the callback.
 **To trigger the callback when the actual element is scrolled**, these settings should be configured:
 * [scrollWindow]="false"
 * set an explict css "height" value to the element
 
 ## DEMO
-- [**Default Scroll** By Window - plunkr](https://plnkr.co/edit/DrEDetYnZkFxR7OWWrxS?p=preview) 
+- [**Default Scroll** By Window - plunkr](https://plnkr.co/edit/DrEDetYnZkFxR7OWWrxS?p=preview)
 - [Scroll On a **"Modal"** - plunkr](https://plnkr.co/edit/QnQOwE9SEapwJCCFII3L?p=preview)
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-infinite-scroll",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "An infinite scroll directive for Angular compatible with AoT compilation and Tree shaking",
     "main": "./bundles/ngx-infinite-scroll.umd.js",
     "module": "./modules/ngx-infinite-scroll.es5.js",

--- a/src/models.ts
+++ b/src/models.ts
@@ -23,6 +23,7 @@ export interface IScrollerConfig {
     up: number;
   };
   scrollParent?: ContainerRef;
+  scrollUpBy: boolean;
 }
 
 export interface IScrollStats {

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -27,6 +27,7 @@ export class InfiniteScrollDirective implements OnDestroy, OnInit {
   @Input() immediateCheck: boolean = false;
   @Input() horizontal: boolean = false;
   @Input() alwaysCallback: boolean = false;
+  @Input() scrollUpBy: boolean = false;
 
   private disposeScroller: Subscription;
 
@@ -61,9 +62,10 @@ export class InfiniteScrollDirective implements OnDestroy, OnInit {
   handleOnScroll(container: IPositionStats) {
     const distance = {
       down: this.infiniteScrollDistance,
-      up: this.infiniteScrollUpDistance
+      up: this.infiniteScrollUpDistance,
     };
-    const scrollStats: IScrollStats = this.scrollerResolver.getScrollStats(container, { distance });
+    const scrollUpBy: boolean = this.scrollUpBy;
+    const scrollStats: IScrollStats = this.scrollerResolver.getScrollStats(container, { distance, scrollUpBy });
     if (this.shouldTriggerEvents(scrollStats.shouldScroll)) {
       const infiniteScrollEvent: InfiniteScrollEvent = {
         currentScrollPosition: container.scrolledUntilNow

--- a/src/services/scroll-resolver.ts
+++ b/src/services/scroll-resolver.ts
@@ -7,14 +7,19 @@ export class ScrollResolver {
 
   shouldScroll (container: IPositionStats, config: IScrollerConfig, scrollingDown: boolean) {
     const distance = config.distance;
+    const scrollUpBy = config.scrollUpBy;
     let remaining: number;
     let containerBreakpoint: number;
     if (scrollingDown) {
-      remaining = container.totalToScroll - container.scrolledUntilNow;
       containerBreakpoint = container.height * distance.down + 1;
+      remaining = container.totalToScroll - container.scrolledUntilNow;
     } else {
-      remaining = container.scrolledUntilNow;
       containerBreakpoint = container.height * distance.up + 1;
+      if (scrollUpBy === false) {
+        remaining = container.scrolledUntilNow;
+      } else {
+        remaining = this.lastScrollPosition - container.scrolledUntilNow;
+      }
     }
     const shouldScroll: boolean = remaining <= containerBreakpoint;
     this.lastScrollPosition = container.scrolledUntilNow;

--- a/tests/modules/infinite-scroll.directive.spec.ts
+++ b/tests/modules/infinite-scroll.directive.spec.ts
@@ -58,6 +58,7 @@ describe('Infinite Scroll Directive', () => {
       infiniteScrollDistance: 2,
       infiniteScrollThrottle: 300,
       infiniteScrollUpDistance: 1.5,
+      scrollUpBy: false,
       scrollWindow: true
     };
 


### PR DESCRIPTION
Hi @orizens,
I have a simple use case that I need to show a popup when a user scrolls up by just a half-screen - not half-screen to the top. So I've added this as a property: **scrollUpBy: boolean**. Now, the naming could be better, got any ideas? Also, I'm not sure what kind of version change should this be - it's just adding a feature, but it may break other directives that use `[scrollUpBy]=""` as input.
Now, the tests don't seem to test an actual distance, scrolling events etc, so I didn't add much there.

Is this acceptable? I'm willing to work a bit more on this if needed. If not, I might just publish this under my namespace and (try to) keep it up to date.