### PR TITLE
Re-initialize scroll container when "infiniteScrollContainer" changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ngx-infinite-scroll",
-    "version": "0.5.1",
-    "description": "An infinite scroll directive for Angular compatible with AoT compilation and Tree shaking",
+    "version": "0.5.2-celum.1",
+    "description": "An infinite scroll directive for Angular compatible with AoT compilation and Tree shaking. With CELUM bugfix",
     "main": "./bundles/ngx-infinite-scroll.umd.js",
     "module": "./modules/ngx-infinite-scroll.es5.js",
     "es2015": "./modules/ngx-infinite-scroll.js",
@@ -17,9 +17,8 @@
     },
     "typings": "./index.d.ts",
     "author": "Oren Farhi (orizens.com)",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/orizens/ngx-infinite-scroll.git"
+    "publishConfig": {
+        "registry": "https://nexus.celum.company/repository/npm-internal/"
     },
     "bugs": {
         "url": "https://github.com/orizens/ngx-infinite-scroll/issues"

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -43,7 +43,7 @@ export class InfiniteScrollDirective implements OnDestroy, OnInit {
   }
 
   ngOnChanges({ infiniteScrollContainer }: SimpleChanges) {
-    if (infiniteScrollContainer) {
+    if (infiniteScrollContainer && !infiniteScrollContainer.firstChange) {
       this.init();
     }
   }

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -36,9 +36,19 @@ export class InfiniteScrollDirective implements OnDestroy, OnInit {
     private positionResolver: PositionResolver,
     private scrollRegister: ScrollRegister,
     private scrollerResolver: ScrollResolver
-  ) {}
+  ) { }
 
   ngOnInit() {
+    this.init();
+  }
+
+  ngOnChanges({ infiniteScrollContainer }: SimpleChanges) {
+    if (infiniteScrollContainer) {
+      this.init();
+    }
+  }
+
+  private init() {
     if (typeof window !== 'undefined') {
       this.zone.runOutsideAngular(() => {
         const containerElement = this.resolveContainerElement();
@@ -80,7 +90,7 @@ export class InfiniteScrollDirective implements OnDestroy, OnInit {
     return (this.alwaysCallback || shouldScroll) && !this.infiniteScrollDisabled;
   }
 
-  ngOnDestroy () {
+  ngOnDestroy() {
     if (this.disposeScroller) {
       this.disposeScroller.unsubscribe();
     }
@@ -97,7 +107,7 @@ export class InfiniteScrollDirective implements OnDestroy, OnInit {
   private resolveContainerElement(): any {
     const selector = this.infiniteScrollContainer;
     const hasWindow = window && window.hasOwnProperty('document');
-    const containerIsString = selector && hasWindow && typeof(this.infiniteScrollContainer) === 'string';
+    const containerIsString = selector && hasWindow && typeof (this.infiniteScrollContainer) === 'string';
     let container = containerIsString
       ? window.document.querySelector(selector)
       : selector;

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -106,7 +106,7 @@ export class InfiniteScrollDirective implements OnDestroy, OnInit {
 
   private resolveContainerElement(): any {
     const selector = this.infiniteScrollContainer;
-    const hasWindow = window && window.hasOwnProperty('document');
+    const hasWindow = window && window.document && window.document.documentElement;
     const containerIsString = selector && hasWindow && typeof (this.infiniteScrollContainer) === 'string';
     let container = containerIsString
       ? window.document.querySelector(selector)

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -12,7 +12,8 @@ import { AxisResolver } from '../services/axis-resolver';
 import { Subscription } from 'rxjs/Subscription';
 
 @Directive({
-  selector: '[infiniteScroll], [infinite-scroll], [data-infinite-scroll]'
+  selector: '[infiniteScroll], [infinite-scroll], [data-infinite-scroll]',
+  providers: [ScrollResolver]
 })
 export class InfiniteScrollDirective implements OnDestroy, OnInit {
   @Output() scrolled = new EventEmitter<InfiniteScrollEvent>();

--- a/src/modules/ngx-infinite-scroll.module.ts
+++ b/src/modules/ngx-infinite-scroll.module.ts
@@ -11,8 +11,7 @@ import { ScrollResolver } from '../services/scroll-resolver';
   imports: [],
   providers: [
     PositionResolver,
-    ScrollRegister,
-    ScrollResolver
+    ScrollRegister
   ]
 })
 export class InfiniteScrollModule { }

--- a/tests/modules/infinite-scroll.directive.spec.ts
+++ b/tests/modules/infinite-scroll.directive.spec.ts
@@ -149,6 +149,23 @@ describe('Infinite Scroll Directive', () => {
           expect(positionFactoryMock.create)
               .toHaveBeenCalledWith(jasmine.objectContaining({windowElement: container}));
         });
+
+        it('should initialize again when infiniteScrollContainer has changed', () => {
+          const anotherContainer = {
+            height: 0,
+            scrolledUntilNow: 0,
+            totalToScroll: 0,
+          };
+
+          directive.infiniteScrollContainer = anotherContainer;
+
+          const change = new SimpleChange(container, anotherContainer, false);
+          
+          directive.ngOnChanges({ infiniteScrollContainer: change });
+
+          expect(positionFactoryMock.create)
+              .toHaveBeenCalledWith(jasmine.objectContaining({windowElement: anotherContainer}));
+        });
       });
     });
 


### PR DESCRIPTION
Hi,

I propose to re-initialize the scroll container when "infiniteScrollContainer" changes. 
I have the use case that the scroll container does not exist yet in the DOM when the directive is initialized. So I can neither pass the element itself nor a css class for the directive to query the container from the DOM. To make it work for this use case I just initialize the directive again with the new container when this specific input changes. 
So in my case, I can pass null as "infiniteScrollContainer" in the beginning and pass the actual scroll container element itself as soon as I have it at hand.

What do you think? Are there any concerns regarding this approach? Do you maybe have another/better solution to prevent errors in this case?

Thanks
Madeleine