### PR TITLE
Allow changing infiniteScrollDisabled

### DIFF
--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -43,8 +43,8 @@ export class InfiniteScrollDirective
     this.setup();
   }
 
-  ngOnChanges({ infiniteScrollContainer }: SimpleChanges) {
-    if (inputPropChanged(infiniteScrollContainer)) {
+  ngOnChanges({ infiniteScrollContainer, infiniteScrollDisabled }: SimpleChanges) {
+    if (inputPropChanged(infiniteScrollContainer) || inputPropChanged(infiniteScrollDisabled)) {
       this.destroyScroller();
       this.setup();
     }

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -46,11 +46,14 @@ export class InfiniteScrollDirective
   }
 
   ngOnChanges({ infiniteScrollContainer, infiniteScrollDisabled }: SimpleChanges) {
-    if (inputPropChanged(infiniteScrollContainer) || inputPropChanged(infiniteScrollDisabled)) {
+    var containerChanged: boolean = inputPropChanged(infiniteScrollContainer);
+    var disabledChanged: boolean = inputPropChanged(infiniteScrollDisabled)
+    
+    if (containerChanged || disabledChanged) {
       this.destroyScroller();
       
-      if ((!inputPropChanged(infiniteScrollDisabled) && !this.infiniteScrollDisabled) ||
-          (inputPropChanged(infiniteScrollDisabled) && !infiniteScrollDisabled.currentValue)) {
+      if ((!disabledChanged && !this.infiniteScrollDisabled) ||
+          (disabledChanged && !infiniteScrollDisabled.currentValue)) {
         this.setup();
       }
     }

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -49,7 +49,7 @@ export class InfiniteScrollDirective
     if (inputPropChanged(infiniteScrollContainer) || inputPropChanged(infiniteScrollDisabled)) {
       this.destroyScroller();
       
-      if ((!inputPropChanged(infiniteScrollDisabled) && !this.infiniteScrollDisabled)) ||
+      if ((!inputPropChanged(infiniteScrollDisabled) && !this.infiniteScrollDisabled) ||
           (inputPropChanged(infiniteScrollDisabled) && !infiniteScrollDisabled.currentValue)) {
         this.setup();
       }

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -46,8 +46,8 @@ export class InfiniteScrollDirective
   }
 
   ngOnChanges({ infiniteScrollContainer, infiniteScrollDisabled }: SimpleChanges) {
-    var containerChanged: boolean = inputPropChanged(infiniteScrollContainer);
-    var disabledChanged: boolean = inputPropChanged(infiniteScrollDisabled)
+    const containerChanged: boolean = inputPropChanged(infiniteScrollContainer);
+    const disabledChanged: boolean = inputPropChanged(infiniteScrollDisabled)
     
     if (containerChanged || disabledChanged) {
       this.destroyScroller();

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -40,13 +40,19 @@ export class InfiniteScrollDirective
   constructor(private element: ElementRef, private zone: NgZone) {}
 
   ngAfterViewInit() {
-    this.setup();
+    if (!this.infiniteScrollDisabled) {
+      this.setup();
+    }
   }
 
   ngOnChanges({ infiniteScrollContainer, infiniteScrollDisabled }: SimpleChanges) {
     if (inputPropChanged(infiniteScrollContainer) || inputPropChanged(infiniteScrollDisabled)) {
       this.destroyScroller();
-      this.setup();
+      
+      if ((!inputPropChanged(infiniteScrollDisabled) && !this.infiniteScrollDisabled)) ||
+          (inputPropChanged(infiniteScrollDisabled) && !infiniteScrollDisabled.currentValue)) {
+        this.setup();
+      }
     }
   }
 

--- a/src/modules/infinite-scroll.directive.ts
+++ b/src/modules/infinite-scroll.directive.ts
@@ -46,8 +46,8 @@ export class InfiniteScrollDirective
   }
 
   ngOnChanges({ infiniteScrollContainer, infiniteScrollDisabled }: SimpleChanges) {
-    const containerChanged: boolean = inputPropChanged(infiniteScrollContainer);
-    const disabledChanged: boolean = inputPropChanged(infiniteScrollDisabled)
+    const containerChanged = inputPropChanged(infiniteScrollContainer);
+    const disabledChanged = inputPropChanged(infiniteScrollDisabled)
     
     if (containerChanged || disabledChanged) {
       this.destroyScroller();


### PR DESCRIPTION
If infiniteScrollDisabled is changed, call setup() again to recreate the scroller.

Fix for Issue #195 