### PR TITLE
Fix for IE 11.

### DIFF
--- a/src/services/ngx-ins-utils.ts
+++ b/src/services/ngx-ins-utils.ts
@@ -6,7 +6,7 @@ export function resolveContainerElement(
   defaultElement,
   fromRoot: boolean
 ): any {
-  const hasWindow = window && window.hasOwnProperty('document');
+  const hasWindow = window && !!window.document;
   const containerIsString =
     selector && hasWindow && typeof selector === 'string';
   let container = hasWindow && scrollWindow ? window : defaultElement;


### PR DESCRIPTION
window.hasOwnProperty('document') dosn't work in IE 11.