### PR TITLE
Fix delay for `scrolled` callback

### DIFF
--- a/src/services/scroll-register.ts
+++ b/src/services/scroll-register.ts
@@ -63,9 +63,14 @@ export function createScroller(config: Models.IScroller) {
 }
 
 export function attachScrollEvent(options: Models.IScrollRegisterConfig): Observable<{}> {
-  return Observable
-    .fromEvent(options.container, 'scroll')
-    .sampleTime(options.throttle);
+  let obs = Observable.fromEvent(options.container, 'scroll');
+  // For an unknown reason calling `sampleTime()` causes trouble for many users, even with `options.throttle = 0`.
+  // Let's avoid calling the function unless needed.
+  // See https://github.com/orizens/ngx-infinite-scroll/issues/198
+  if (options.throttle) {
+    obs = obs.sampleTime(options.throttle);
+  }
+  return obs;
 }
 
 export function toInfiniteScrollParams(


### PR DESCRIPTION
Multiple users (including me) report a problem: the scroll function
callback is called many seconds after it should be.
It's not clear if the problem comes from `ngx-infinite-scroll` or
another library (`RxJS`?).

However, there's a simple fix that allows solving the bug by using
`infiniteScrollThrottle="0"`. Let's apply it!

Fixes https://github.com/orizens/ngx-infinite-scroll/issues/198