### PR TITLE
Corrects order of shouldTriggerEvents() parameters

### DIFF
--- a/src/services/scroll-register.ts
+++ b/src/services/scroll-register.ts
@@ -54,7 +54,7 @@ export function createScroller(config: Models.IScroller) {
       ))
     .filter(({ fire, scrollDown, stats: { totalToScroll } }: Models.IScrollParams) =>
       shouldTriggerEvents(
-        fire, config.alwaysCallback, ScrollResolver.isTriggeredScroll(totalToScroll, scrollState, scrollDown))
+        config.alwaysCallback, fire, ScrollResolver.isTriggeredScroll(totalToScroll, scrollState, scrollDown))
     )
     .do(({ scrollDown, stats: { totalToScroll } }: Models.IScrollParams) => {
       ScrollResolver.updateTriggeredFlag(totalToScroll, scrollState, true, scrollDown);


### PR DESCRIPTION
See https://github.com/orizens/ngx-infinite-scroll/blob/master/src/services/event-trigger.ts#L28 for the correct order.

The wrong order didn't have any impact yet, as both booleans are used symmetrically in shouldTriggerEvents().

I'm skipping the other requirements for PRs due to the smallness of this change.