### PR TITLE
bugfix getElementHeight on SSR

### DIFF
--- a/src/services/position-resolver.ts
+++ b/src/services/position-resolver.ts
@@ -109,7 +109,8 @@ export function getElementHeight(
   clientHeightKey: string
 ) {
   if (isNaN(elem[offsetHeightKey])) {
-    return getDocumentElement(isWindow, elem)[clientHeightKey];
+    const docElem = getDocumentElement(isWindow, elem);
+    return docElem ? docElem[clientHeightKey] : 0;
   } else {
     return elem[offsetHeightKey];
   }


### PR DESCRIPTION
Request a bug fix.
This bug occurs when using SSR (Angular-Universal).

TypeError: Cannot read property 'clientHeight' of null
position-resolver.ts:112:46