### PR TITLE
Fix the wrong calculations when scroll up event should be fired.

### DIFF
--- a/src/services/scroll-resolver.ts
+++ b/src/services/scroll-resolver.ts
@@ -12,7 +12,8 @@ export function shouldFireScrollEvent(
     remaining = (container.totalToScroll - scrolledUntilNow) / container.totalToScroll;
     containerBreakpoint = distance.down / 10;
   } else {
-    remaining = scrolledUntilNow / container.totalToScroll;
+    const totalHiddenContentHeight = container.scrolled + (container.totalToScroll - scrolledUntilNow);
+    remaining = container.scrolled / totalHiddenContentHeight;
     containerBreakpoint = distance.up / 10;
   }
 


### PR DESCRIPTION
We should check against the hidden content height instead of the total scroll + content height.

**Summary**

This PR fixes the following **bugs** connected to not firing the scroll up event at the right moment defined by the parameter infiniteScrollUpDistance.

- [ X] #250 
- [ X] #273 
- [ X] #267

Before this fix the scroll up event was not fired when the shown content was bigger than the remaining (hidden) part (on small scroll bar). 
It was (partially) working only when the scroll bar was small enough (much hidden content), but the place where the scroll up event has been fired was not following the given percentages by the param "infiniteScrollUpDistance".
In the demo (https://stackblitz.com/edit/ngx-infinite-scroll) example you can reproduce the issue:
 1. Open the demo link but be sure your browser's height is >= 970px;
 2. Scroll a bit down.
 3. Scroll up to the top -> nothing will be loaded.
 4. Reduce the browser's height <= 300px;
 5. Scroll a bit down.
 6. Scroll a bit up -> it'll prepend the content.

Expected behavior: 
The content should be prepended when we reach <= 15% of the scrollable area.
Actual: 
Sometimes it fires the event and sometimes not.

Make sure these boxes are checked:  
- [x] link to an issue
- [x] tests run successfully (local) 
- [x] tests run successfully (TravisCI) 
- [x] please follow this [styleguide](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#subject-line) for this pr title 