### PR TITLE
Update postinstall so that it doesn't cause failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "compodoc-serve": "compodoc -s",
     "transpile": "ngc -p ./tsconfig.json",
     "serve:prod": "npm run build && lite-server -c ./example/bs-config.json",
-    "postinstall": "opencollective-postinstall"
+    "postinstall": "opencollective-postinstall || exit 0"
   },
   "typings": "./ngx-infinite-scroll.d.ts",
   "author": "Oren Farhi (orizens.com)",


### PR DESCRIPTION
There are a few known scenarios where the opencollective postinstall npm script can cause things to break further down the pipeline - a few being 'certain build/CI environments', 'script permission issues' and 'offline installs'.... 

Arguably, displaying a banner soliciting funding shouldn't disrupt the development or build processes of projects leveraging libraries that are optionally, and non-functionally, using opencollective.

Ultimately, at the heart of the failure, is a non 0 exit code being returned in the cases that opencollective fails to properly execute. 

To prevent this non-zero exit code failure so that subsequent npm processes aren't disrupted as a result of non-functional dependency issues, a "|| exit 0" should be added to the postinstall npm script.

There are many discussions about this issue and workaround - here are a few:
opencollective/opencollective-cli#5
nuxt/nuxt.js#1357
opencollective/opencollective-cli#3
opencollective/opencollective-postinstall#2
https://github.com/compodoc/compodoc/commit/99ea09f6ac75fe26001c2fae52facc3be1696a52
