### PR TITLE
Update postinstall so that it doesn't cause failures for Angular 6 (#321 #329)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-infinite-scroll",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "An infinite scroll directive for Angular compatible with AoT compilation and Tree shaking",
   "main": "./bundles/ngx-infinite-scroll.umd.js",
   "module": "./modules/ngx-infinite-scroll.es5.js",
@@ -16,7 +16,7 @@
     "compodoc-serve": "compodoc -s",
     "transpile": "ngc -p ./tsconfig.json",
     "serve:prod": "npm run build && lite-server -c ./example/bs-config.json",
-    "postinstall": "opencollective postinstall"
+    "postinstall": "opencollective-postinstall || exit 0"
   },
   "typings": "./ngx-infinite-scroll.d.ts",
   "author": "Oren Farhi (orizens.com)",
@@ -75,7 +75,7 @@
     "zone.js": "^0.8.26"
   },
   "dependencies": {
-    "opencollective": "^1.0.3"
+    "opencollective-postinstall": "^2.0.2"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
This changes has been cherry-picked from the PR made for #321 and fixes #329. An ng-6 branch has been created from the 6.0.1 release.

---

There are a few known scenarios where the opencollective postinstall npm script can cause things to break further down the pipeline - a few being 'certain build/CI environments', 'script permission issues' and 'offline installs'....

Arguably, displaying a banner soliciting funding shouldn't disrupt the development or build processes of projects leveraging libraries that are optionally, and non-functionally, using opencollective.

Ultimately, at the heart of the failure, is a non 0 exit code being returned in the cases that opencollective fails to properly execute.

To prevent this non-zero exit code failure so that subsequent npm processes aren't disrupted as a result of non-functional dependency issues, a "|| exit 0" should be added to the postinstall npm script.

There are many discussions about this issue and workaround - here are a few:
opencollective/opencollective-cli#5
nuxt/nuxt.js#1357
opencollective/opencollective-cli#3
opencollective/opencollective-postinstall#2
https://github.com/compodoc/compodoc/commit/99ea09f6ac75fe26001c2fae52facc3be1696a52

(cherry picked from commit c5613d7386cbbe074e5bb62a77bba85e906060fb)
