### PR TITLE
fix(attachScrollEvent): Add trailing:true to throttleTime

### DIFF
--- a/src/services/scroll-register.ts
+++ b/src/services/scroll-register.ts
@@ -67,7 +67,7 @@ export function attachScrollEvent(
   // Replacing with throttleTime seems to solve the problem
   // See https://github.com/orizens/ngx-infinite-scroll/issues/198
   if (options.throttle) {
-    obs = obs.pipe(throttleTime(options.throttle));
+    obs = obs.pipe(throttleTime(options.throttle, undefined, { leading: true, trailing: true }));
   }
   return obs;
 }


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. 

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

- [x] #385 
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

When scrolling too fast, it may miss to capture some scrolling event that would have triggered the scrolled / scrolledUp event.
This PR fix this issue by setting the trailing attribute to true in throttleTime.
This will emit the last value received at the end of the throttle interval, solving this problem.

### Requirements
Make sure these boxes are checked:  
- [x] link to an issue
- [x] tests are updated (added/changed/removed): No need to change the tests
- [ ] tests run successfully (local): With or without the change 1 test fails. I don't think this is caused by my change.
- [ ] tests run successfully (TravisCI) 
- [x] please follow this [styleguide](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#subject-line) for this pr title 