### PR TITLE
feat: switch to signal inputs to support zoneless change detection

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -52,7 +52,7 @@
               "base": "dist/demo"
             },
             "index": "projects/demo/src/index.html",
-            "polyfills": ["zone.js"],
+            "polyfills": [],
             "tsConfig": "projects/demo/tsconfig.app.json",
             "assets": [
               "projects/demo/src/favicon.ico",

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -9,7 +9,9 @@
 
 <style>
   :host {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+      "Segoe UI Symbol";
     font-size: 14px;
     color: #333;
     box-sizing: border-box;
@@ -201,7 +203,7 @@
   }
 
   .terminal pre {
-    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
+    font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
     color: white;
     padding: 0 1rem 1rem;
     margin: 0;
@@ -245,17 +247,17 @@
     align-items: center;
     font-size: 12px;
     padding: 3px 10px;
-    border: 1px solid rgba(27,31,35,.2);
+    border: 1px solid rgba(27, 31, 35, 0.2);
     border-radius: 3px;
-    background-image: linear-gradient(-180deg,#fafbfc,#eff3f6 90%);
+    background-image: linear-gradient(-180deg, #fafbfc, #eff3f6 90%);
     margin-left: 4px;
     font-weight: 600;
   }
 
   .github-star-badge:hover {
-    background-image: linear-gradient(-180deg,#f0f3f6,#e6ebf1 90%);
-    border-color: rgba(27,31,35,.35);
-    background-position: -.5em;
+    background-image: linear-gradient(-180deg, #f0f3f6, #e6ebf1 90%);
+    border-color: rgba(27, 31, 35, 0.35);
+    background-position: -0.5em;
   }
 
   .github-star-badge .material-icons {
@@ -274,7 +276,7 @@
 
   /* Responsive Styles */
   @media screen and (max-width: 767px) {
-    .card-container > *:not(.circle-link) ,
+    .card-container > *:not(.circle-link),
     .terminal {
       width: 100%;
     }
@@ -310,38 +312,37 @@
     src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg=="
   />
   <span>Welcome To ngx-infinite-scroll</span>
-
 </div>
 
 <div class="content" role="main">
-
   <!-- Highlight Card -->
-  <div class="card highlight-card card-small">
-
-  </div>
+  <div class="card highlight-card card-small"></div>
 
   <h1 class="title well">
     ngx-infinite-scroll
     <section>
-    <small>items: {{sum}}, now triggering scroll: {{direction}}</small>
+      <small
+        >items: {{ sum() }}, now triggering scroll: {{ direction() }}</small
+      >
     </section>
     <section>
-      <button class="btn btn-info" (click)="toggleModal()">Open Infinite Scroll in Modal</button>
+      <button class="btn btn-info" (click)="toggleModal()">
+        Open Infinite Scroll in Modal
+      </button>
     </section>
   </h1>
-  <modal *ngIf="modalOpen" (onClose)="toggleModal()"></modal>
-  <div class="search-results"
-        infinite-scroll
-        [infiniteScrollDistance]="scrollDistance"
-        [infiniteScrollUpDistance]="scrollUpDistance"
-        [infiniteScrollThrottle]="throttle"
-        (scrolled)="onScrollDown()"
-        (scrolledUp)="onUp()">
-    <p *ngFor="let i of array">
+  <modal *ngIf="modalOpen()" (onClose)="toggleModal()"></modal>
+  <div
+    class="search-results"
+    infinite-scroll
+    [infiniteScrollDistance]="scrollDistance()"
+    [infiniteScrollUpDistance]="scrollUpDistance()"
+    [infiniteScrollThrottle]="throttle()"
+    (scrolled)="onScrollDown()"
+    (scrolledUp)="onUp()"
+  >
+    <p *ngFor="let i of array()">
       {{ i }}
     </p>
   </div>
-
-
 </div>
-

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,38 +1,38 @@
-import {CommonModule} from "@angular/common";
-import { Component } from '@angular/core';
-import { InfiniteScrollModule } from "ngx-infinite-scroll";
-import { ModalComponent } from "./modal/modal.component";
+import { CommonModule } from '@angular/common';
+import { Component, signal } from '@angular/core';
+import { InfiniteScrollModule } from 'ngx-infinite-scroll';
+import { ModalComponent } from './modal/modal.component';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
   standalone: true,
-  imports: [CommonModule, InfiniteScrollModule, ModalComponent]
+  imports: [CommonModule, InfiniteScrollModule, ModalComponent],
 })
 export class AppComponent {
   title = 'demo';
-  array: string[] = [];
-  sum = 100;
-  throttle = 300;
-  scrollDistance = 1;
-  scrollUpDistance = 2;
-  direction = '';
-  modalOpen = false;
+  array = signal<string[]>([]);
+  sum = signal(100);
+  throttle = signal(300);
+  scrollDistance = signal(1);
+  scrollUpDistance = signal(2);
+  direction = signal('');
+  modalOpen = signal(false);
 
   // nisVersion = nisPackage.dependencies["ngx-infinite-scroll"];
 
   constructor() {
-    this.appendItems(0, this.sum);
+    this.appendItems(0, this.sum());
   }
 
   addItems(startIndex: number, endIndex: number, _method: 'push' | 'unshift') {
-    for (let i = 0; i < this.sum; ++i) {
+    for (let i = 0; i < this.sum(); ++i) {
       const value = [i, ' ', this.generateWord()].join('');
       if (_method === 'push') {
-        this.array.push(value);
+        this.array.update((array) => [...array, value]);
       } else {
-        this.array.unshift(value);
+        this.array.update((array) => [value, ...array]);
       }
     }
   }
@@ -49,20 +49,20 @@ export class AppComponent {
     // console.log('scrolled down!!', ev);
 
     // add another 20 items
-    const start = this.sum;
-    this.sum += 20;
-    this.appendItems(start, this.sum);
+    const start = this.sum();
+    this.sum.update((sum) => sum + 20);
+    this.appendItems(start, this.sum());
 
-    this.direction = 'down';
+    this.direction.set('down');
   }
 
   onUp() {
     // console.log('scrolled up!', ev);
-    const start = this.sum;
-    this.sum += 20;
-    this.prependItems(start, this.sum);
+    const start = this.sum();
+    this.sum.update((sum) => sum + 20);
+    this.prependItems(start, this.sum());
 
-    this.direction = 'up';
+    this.direction.set('up');
   }
   generateWord() {
     return Math.random() * 3342411313;
@@ -70,6 +70,6 @@ export class AppComponent {
   }
 
   toggleModal() {
-    this.modalOpen = !this.modalOpen;
+    this.modalOpen.update((modalOpen) => !modalOpen);
   }
 }

--- a/projects/demo/src/app/modal/modal.component.ts
+++ b/projects/demo/src/app/modal/modal.component.ts
@@ -1,28 +1,28 @@
-import { Component, Output, EventEmitter } from '@angular/core';
-import { InfiniteScrollModule } from "ngx-infinite-scroll";
+import { Component, Output, EventEmitter, signal } from '@angular/core';
+import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 
 @Component({
   selector: 'modal',
   templateUrl: './modal.html',
   standalone: true,
-  imports: [InfiniteScrollModule]
+  imports: [InfiniteScrollModule],
 })
 export class ModalComponent {
   @Output() onClose = new EventEmitter();
 
-  array: number[] = [];
-  sum = 100;
+  array = signal<number[]>([]);
+  sum = signal(100);
 
-  modalIsOpen = '';
-  modalTitle = 'scroll to update';
-  modalBody = modalText;
+  modalIsOpen = signal('');
+  modalTitle = signal('scroll to update');
+  modalBody = signal(modalText);
 
-  modalScrollDistance = 2;
-  modalScrollThrottle = 50;
+  modalScrollDistance = signal(2);
+  modalScrollThrottle = signal(50);
 
   constructor() {
-    for (let i = 0; i < this.sum; ++i) {
-      this.array.push(i);
+    for (let i = 0; i < this.sum(); ++i) {
+      this.array.update((array) => [...array, i]);
     }
     this.open();
   }
@@ -31,24 +31,25 @@ export class ModalComponent {
     console.log('scrolled!!');
 
     // add another 20 items
-    const start = this.sum;
-    this.sum += 20;
-    for (let i = start; i < this.sum; ++i) {
-      this.array.push(i);
+    const start = this.sum();
+    this.sum.update(sum => sum + 20);
+    for (let i = start; i < this.sum(); ++i) {
+      this.array.update((array) => [...array, i]);
     }
   }
 
   onModalScrollDown() {
-    this.modalTitle = 'updated on ' + new Date().toString();
-    this.modalBody += modalText;
+    this.modalTitle.set('updated on ' + new Date().toString());
+    this.modalBody.update((modalBody) => modalBody + modalText);
   }
+
   open() {
-    this.modalIsOpen = 'in modal-open';
+    this.modalIsOpen.set('in modal-open');
   }
 
   close() {
-    this.modalIsOpen = '';
-    this.modalBody = modalText;
+    this.modalIsOpen.set('');
+    this.modalBody.set(modalText);
     this.onClose.emit();
   }
 }

--- a/projects/demo/src/app/modal/modal.html
+++ b/projects/demo/src/app/modal/modal.html
@@ -1,23 +1,37 @@
-<div class="modal fade {{ modalIsOpen }}" tabindex="-1" role="dialog">
+<div class="modal fade {{ modalIsOpen() }}" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close" (click)="close()"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">{{ modalTitle }}</h4>
+        <button
+          type="button"
+          class="close"
+          data-dismiss="modal"
+          aria-label="Close"
+          (click)="close()"
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title">{{ modalTitle() }}</h4>
       </div>
-      <div class="modal-body"
+      <div
+        class="modal-body"
         infinite-scroll
-        [infiniteScrollDistance]="modalScrollDistance"
-        [infiniteScrollThrottle]="modalScrollThrottle"
+        [infiniteScrollDistance]="modalScrollDistance()"
+        [infiniteScrollThrottle]="modalScrollThrottle()"
         [scrollWindow]="false"
         (scrolled)="onModalScrollDown()"
-        >
-        <p>
-          {{ modalBody }}
-        </p>
+      >
+        <p>{{ modalBody() }}</p>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal" (click)="close()">Close</button>
+        <button
+          type="button"
+          class="btn btn-default"
+          data-dismiss="modal"
+          (click)="close()"
+        >
+          Close
+        </button>
       </div>
     </div>
   </div>

--- a/projects/demo/src/main.ts
+++ b/projects/demo/src/main.ts
@@ -1,12 +1,16 @@
-import { enableProdMode, importProvidersFrom } from '@angular/core';
-import { bootstrapApplication } from "@angular/platform-browser";
-import { AppComponent } from "./app/app.component";
-import { BrowserModule } from '@angular/platform-browser';
+import {
+  enableProdMode,
+  provideExperimentalZonelessChangeDetection,
+} from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+
+import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();
 }
 
-bootstrapApplication(AppComponent, {providers: [importProvidersFrom(BrowserModule)]})
-  .catch(err => console.error(err));
+bootstrapApplication(AppComponent, {
+  providers: [provideExperimentalZonelessChangeDetection()],
+}).catch((err) => console.error(err));

--- a/projects/ngx-infinite-scroll/src/lib/services/ngx-ins-utils.ts
+++ b/projects/ngx-infinite-scroll/src/lib/services/ngx-ins-utils.ts
@@ -6,7 +6,8 @@ export function resolveContainerElement(
   defaultElement: ElementRef<any>,
   fromRoot: boolean
 ): any {
-  const hasWindow = window && !!window.document && window.document.documentElement;
+  const hasWindow =
+    window && !!window.document && window.document.documentElement;
   let container = hasWindow && scrollWindow ? window : defaultElement;
   if (selector) {
     const containerIsString =
@@ -15,7 +16,9 @@ export function resolveContainerElement(
       ? findElement(selector, defaultElement.nativeElement, fromRoot)
       : selector;
     if (!container) {
-      throw new Error('ngx-infinite-scroll {resolveContainerElement()}: selector for');
+      throw new Error(
+        'ngx-infinite-scroll {resolveContainerElement()}: selector for'
+      );
     }
   }
   return container;
@@ -32,8 +35,4 @@ export function findElement(
 
 export function inputPropChanged(prop: SimpleChange): boolean {
   return prop && !prop.firstChange;
-}
-
-export function hasWindowDefined(): boolean {
-  return typeof window !== 'undefined';
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,7 @@
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "paths": {
-      "ngx-infinite-scroll": [
-        "dist/ngx-infinite-scroll/ngx-infinite-scroll",
-        "dist/ngx-infinite-scroll"
-      ]
+      "ngx-infinite-scroll": ["projects/ngx-infinite-scroll/src/public-api.ts"]
     },
     "declaration": false,
     "experimentalDecorators": true,
@@ -24,10 +21,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "es2020",
-    "lib": [
-      "es2020",
-      "dom"
-    ],
+    "lib": ["es2020", "dom"],
     "useDefineForClassFields": false,
     "removeComments": false
   },


### PR DESCRIPTION
In this commit, we changed `@Input` to signal inputs, supporting zoneless change detection introduced experimentally in Angular 17. Many apps have already adopted zoneless change detection since Angular 17. However, this change is necessary to notify the zoneless scheduler about updates to signals. Whenever signals are updated, it can schedule change detection.